### PR TITLE
feat: add arbitrary batch permit

### DIFF
--- a/src/base/ArbitraryExecutionPermit2Adapter.sol
+++ b/src/base/ArbitraryExecutionPermit2Adapter.sol
@@ -38,6 +38,23 @@ abstract contract ArbitraryExecutionPermit2Adapter is BasePermit2Adapter, IArbit
     return _approveExecuteAndTransfer(_allowanceTargets, _contractCalls, _transferOut);
   }
 
+  /// @inheritdoc IArbitraryExecutionPermit2Adapter
+  function executeWithBatchPermit(
+    BatchPermit calldata _batchPermit,
+    AllowanceTarget[] calldata _allowanceTargets,
+    ContractCall[] calldata _contractCalls,
+    TransferOut[] calldata _transferOut,
+    uint256 _deadline
+  )
+    external
+    payable
+    checkDeadline(_deadline)
+    returns (bytes[] memory _executionResults, uint256[] memory _tokenBalances)
+  {
+    PERMIT2.batchTakeFromCaller(_batchPermit.tokens, _batchPermit.nonce, _deadline, _batchPermit.signature);
+    return _approveExecuteAndTransfer(_allowanceTargets, _contractCalls, _transferOut);
+  }
+
   function _approveExecuteAndTransfer(
     AllowanceTarget[] calldata _allowanceTargets,
     ContractCall[] calldata _contractCalls,

--- a/src/interfaces/IArbitraryExecutionPermit2Adapter.sol
+++ b/src/interfaces/IArbitraryExecutionPermit2Adapter.sol
@@ -2,13 +2,20 @@
 pragma solidity >=0.8.0;
 
 import { Token } from "../libraries/Token.sol";
-import { IBasePermit2Adapter } from "./IBasePermit2Adapter.sol";
+import { IBasePermit2Adapter, IPermit2 } from "./IBasePermit2Adapter.sol";
 
 interface IArbitraryExecutionPermit2Adapter is IBasePermit2Adapter {
   /// @notice Data necessary to execute a single permit transfer
   struct SinglePermit {
     address token;
     uint256 amount;
+    uint256 nonce;
+    bytes signature;
+  }
+
+  /// @notice Data necessary to execute a batch permit transfer
+  struct BatchPermit {
+    IPermit2.TokenPermissions[] tokens;
     uint256 nonce;
     bytes signature;
   }
@@ -46,6 +53,28 @@ interface IArbitraryExecutionPermit2Adapter is IBasePermit2Adapter {
    */
   function executeWithPermit(
     SinglePermit calldata permit,
+    AllowanceTarget[] calldata allowanceTargets,
+    ContractCall[] calldata contractCalls,
+    TransferOut[] calldata transferOut,
+    uint256 deadline
+  )
+    external
+    payable
+    returns (bytes[] memory executionResults, uint256[] memory tokenBalances);
+
+  /**
+   * @notice Executes arbitrary calls by proxing to another contracts, but using Permit2 to transfer tokens from the
+   *         caller
+   * @param batchPermit The permit data to use to batch transfer tokens from the user
+   * @param allowanceTargets The contracts to approve before executing calls
+   * @param contractCalls The calls to execute
+   * @param transferOut The tokens to transfer out of our contract after all calls have been executed
+   * @param deadline The max time where this call can be executed
+   * @return executionResults The results of each contract call
+   * @return tokenBalances The balances held by the contract after contract calls were executed
+   */
+  function executeWithBatchPermit(
+    BatchPermit calldata batchPermit,
     AllowanceTarget[] calldata allowanceTargets,
     ContractCall[] calldata contractCalls,
     TransferOut[] calldata transferOut,

--- a/src/libraries/Permit2Transfers.sol
+++ b/src/libraries/Permit2Transfers.sol
@@ -49,4 +49,52 @@ library Permit2Transfers {
       );
     }
   }
+
+  /**
+   * @notice Executes a batch transfer from using Permit2
+   * @param _permit2 The Permit2 contract
+   * @param _tokens The amount of tokens to transfer
+   * @param _nonce The owner's nonce
+   * @param _deadline The signature's expiration deadline
+   * @param _signature The signature that allows the transfer
+   */
+  function batchTakeFromCaller(
+    IPermit2 _permit2,
+    IPermit2.TokenPermissions[] calldata _tokens,
+    uint256 _nonce,
+    uint256 _deadline,
+    bytes calldata _signature
+  )
+    internal
+  {
+    if (_tokens.length > 0) {
+      _permit2.permitTransferFrom(
+        // The permit message.
+        IPermit2.PermitBatchTransferFrom({ permitted: _tokens, nonce: _nonce, deadline: _deadline }),
+        // The transfer recipients and amounts.
+        _buildTransferDetails(_tokens),
+        // The owner of the tokens, which must also be
+        // the signer of the message, otherwise this call
+        // will fail.
+        msg.sender,
+        // The packed signature that was the result of signing
+        // the EIP712 hash of `permit`.
+        _signature
+      );
+    }
+  }
+
+  function _buildTransferDetails(IPermit2.TokenPermissions[] calldata _tokens)
+    private
+    view
+    returns (IPermit2.SignatureTransferDetails[] memory _details)
+  {
+    _details = new IPermit2.SignatureTransferDetails[](_tokens.length);
+    for (uint256 i; i < _details.length;) {
+      _details[i] = IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: _tokens[i].amount });
+      unchecked {
+        ++i;
+      }
+    }
+  }
 }

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -59,6 +59,24 @@ library Utils {
     });
   }
 
+  // solhint-disable-next-line no-empty-blocks
+  function buildEmptyBatchPermit() internal pure returns (IArbitraryExecutionPermit2Adapter.BatchPermit memory) { }
+
+  function buildBatchPermit(
+    address _token,
+    uint256 _amount,
+    uint256 _nonce,
+    bytes memory _signature
+  )
+    internal
+    pure
+    returns (IArbitraryExecutionPermit2Adapter.BatchPermit memory _permit)
+  {
+    IPermit2.TokenPermissions[] memory _tokens = new IPermit2.TokenPermissions[](1);
+    _tokens[0] = IPermit2.TokenPermissions({ token: _token, amount: _amount });
+    _permit = IArbitraryExecutionPermit2Adapter.BatchPermit({ tokens: _tokens, nonce: _nonce, signature: _signature });
+  }
+
   function buildEmptyAllowanceTargets()
     internal
     pure


### PR DESCRIPTION
We are now adding a way to execute an arbitrary call by executing a batch permit. This adds a lot of cool use cases by transferring multiple tokens with only one signature